### PR TITLE
Fix `CopyTo` APIs

### DIFF
--- a/Tests/HashtableTests/HashtableTests.cs
+++ b/Tests/HashtableTests/HashtableTests.cs
@@ -277,7 +277,7 @@ namespace NFUnitTests
 
             // Assert
             Assert.IsTrue(hashtable.Contains(key1), "Hashtable should contain key1.");
-            Assert.True(hashtable.Contains(key2), "Hashtable should contain key2.");
+            Assert.IsTrue(hashtable.Contains(key2), "Hashtable should contain key2.");
             Assert.AreEqual(value1, hashtable[key1], "The value associated with key1 should be correct.");
             Assert.AreEqual(value2, hashtable[key2], "The value associated with key2 should be correct.");
         }
@@ -1306,6 +1306,267 @@ namespace NFUnitTests
             Assert.IsNull(hashtable[new SomeKey { KeyProperty = "key3" }], "The value for a key that was not added should be null.");
         }
 
+        [TestMethod]
+        public void ValuesCopyTo_IntArray()
+        {
+            // Arrange
+            Hashtable hashtable = new Hashtable();
+            for (int i = 0; i < 10; i++)
+            {
+                hashtable.Add(i, i * 10);
+            }
+
+            int[] array = new int[10];
+
+            // Act
+            hashtable.Values.CopyTo(array, 0);
+
+            // Assert
+            // despite array elements should be the same as the values, they may not be in the same order
+            // a simplistic check is to sum the elements of both arrays and compare the sums
+
+            int sum = 0;
+            int arraySum = 0;
+
+            for (int i = 0; i < 10; i++)
+            {
+                sum += i * 10;
+                arraySum += array[i];
+            }
+
+            Assert.AreEqual(sum, arraySum, "Sum of elements should be the same.");
+        }
+
+        [TestMethod]
+        public void ValuesCopyTo_StringArray()
+        {
+            // Arrange
+            Hashtable hashtable = new Hashtable();
+            for (int i = 0; i < 10; i++)
+            {
+                hashtable.Add(i.ToString(), (i * 10).ToString());
+            }
+
+            string[] array = new string[10];
+
+            // Act
+            hashtable.Values.CopyTo(array, 0);
+
+            // Assert
+            // despite array elements should be the same as the values, they may not be in the same order
+            // a simplistic check is to sum the hash code of elements on both arrays and compare the sums
+
+            int sum = 0;
+            int arraySum = 0;
+
+            for (int i = 0; i < 10; i++)
+            {
+                sum += (i * 10).ToString().GetHashCode();
+                arraySum += array[i].GetHashCode();
+            }
+
+            Assert.AreEqual(sum, arraySum, "Sum of hash codes should be the same.");
+        }
+
+        [TestMethod]
+        public void CopyTo_AnotherKeyArray()
+        {
+            // Arrange
+            Hashtable hashtable = new Hashtable();
+            AnotherKey[] keys = new AnotherKey[10];
+            for (int i = 0; i < 10; i++)
+            {
+                keys[i] = new AnotherKey { Value = i * 1.1 };
+                hashtable.Add(keys[i], i * 10);
+            }
+
+            AnotherKey[] array = new AnotherKey[10];
+
+            // Act
+            hashtable.Keys.CopyTo(array, 0);
+
+            // Assert
+            // despite array elements should be the same as the keys, they may not be in the same order
+            // a simplistic check is to sum the elements of both arrays and compare the sums
+            int keySum = 0;
+            int arraySum = 0;
+            for (int i = 0; i < 10; i++)
+            {
+                keySum += keys[i].id;
+                arraySum += array[i].id;
+            }
+
+            Assert.AreEqual(keySum, arraySum, "Sum of elements should be the same.");
+        }
+
+        [TestMethod]
+        public void CopyTo_FooArray()
+        {
+            // Arrange
+            Hashtable hashtable = new Hashtable();
+            Foo[] keys = new Foo[10];
+            for (int i = 0; i < 10; i++)
+            {
+                keys[i] = new Foo { StringValue = $"foo{i}" };
+                hashtable.Add(keys[i], i * 10);
+            }
+
+            Foo[] array = new Foo[10];
+
+            // Act
+            hashtable.Keys.CopyTo(array, 0);
+
+            // Assert
+            // despite array elements should be the same as the keys, they may not be in the same order
+            // a simplistic check is to sum the hash code of elements of both arrays and compare the sums
+
+            int keySum = 0;
+            int arraySum = 0;
+
+            for (int i = 0; i < 10; i++)
+            {
+                keySum += keys[i].GetHashCode();
+                arraySum += array[i].GetHashCode();
+            }
+
+            Assert.AreEqual(keySum, arraySum, "Sum of hash codes should be the same.");
+        }
+
+        [TestMethod]
+        public void CopyTo_MyClassTypeEntryArray()
+        {
+            // Arrange
+            Hashtable hashtable = new Hashtable();
+            MyClassTypeEntry[] keys = new MyClassTypeEntry[10];
+            for (int i = 0; i < 10; i++)
+            {
+                keys[i] = new MyClassTypeEntry($"string{i}", i, Guid.NewGuid());
+                hashtable.Add(keys[i], i * 10);
+            }
+
+            MyClassTypeEntry[] array = new MyClassTypeEntry[10];
+
+            // Act
+            hashtable.Keys.CopyTo(array, 0);
+
+            // Assert
+            // despite array elements should be the same as the keys, they may not be in the same order
+            // a simplistic check is to sum the hash code of elements of both arrays and compare the sums
+
+            int keySum = 0;
+            int arraySum = 0;
+
+            for (int i = 0; i < 10; i++)
+            {
+                keySum += keys[i].GetHashCode();
+                arraySum += array[i].GetHashCode();
+            }
+
+            Assert.AreEqual(keySum, arraySum, "Sum of hash codes should be the same.");
+        }
+
+        [TestMethod]
+        public void CopyTo_SomeOtherKeyArray()
+        {
+            // Arrange
+            Hashtable hashtable = new Hashtable();
+            SomeOtherKey[] keys = new SomeOtherKey[10];
+            for (int i = 0; i < 10; i++)
+            {
+                keys[i] = new SomeOtherKey(i);
+                hashtable.Add(keys[i], i * 10);
+            }
+
+            SomeOtherKey[] array = new SomeOtherKey[10];
+
+            // Act
+            hashtable.Keys.CopyTo(array, 0);
+
+            // Assert
+            // despite array elements should be the same as the keys, they may not be in the same order
+            // a simplistic check is to sum the hash code of elements of both arrays and compare the sums
+
+            int keySum = 0;
+            int arraySum = 0;
+
+            for (int i = 0; i < 10; i++)
+            {
+                keySum += keys[i].GetHashCode();
+                arraySum += array[i].GetHashCode();
+            }
+
+            Assert.AreEqual(keySum, arraySum, "Sum of hash codes should be the same.");
+        }
+
+        [TestMethod]
+        public void CopyTo_SomeKeyArray()
+        {
+            // Arrange
+            Hashtable hashtable = new Hashtable();
+            SomeKey[] keys = new SomeKey[10];
+            for (int i = 0; i < 10; i++)
+            {
+                keys[i] = new SomeKey { KeyProperty = $"key{i}" };
+                hashtable.Add(keys[i], i * 10);
+            }
+
+            SomeKey[] array = new SomeKey[10];
+
+            // Act
+            hashtable.Keys.CopyTo(array, 0);
+
+            // Assert
+            // despite array elements should be the same as the keys, they may not be in the same order
+            // a simplistic check is to sum the hash code of elements of both arrays and compare the sums
+
+            int keySum = 0;
+            int arraySum = 0;
+
+            for (int i = 0; i < 10; i++)
+            {
+                keySum += keys[i].GetHashCode();
+                arraySum += array[i].GetHashCode();
+            }
+
+            Assert.AreEqual(keySum, arraySum, "Sum of hash codes should be the same.");
+        }
+
+        [TestMethod]
+        public void CopyTo_SomeOtherArray()
+        {
+            // Arrange
+            Hashtable hashtable = new Hashtable();
+            SomeOtherKey[] keys = new SomeOtherKey[10];
+            for (int i = 0; i < 10; i++)
+            {
+                keys[i] = new SomeOtherKey(i);
+                hashtable.Add(keys[i], i * 10);
+            }
+
+            DictionaryEntry[] array = new DictionaryEntry[10];
+
+            // Act
+            hashtable.CopyTo(array, 0);
+
+            // Assert
+            // despite array elements should be the same as the hash table elements, they may not be in the same order
+            // a simplistic check is to sum the values of elements of both arrays and compare the sums
+            // at the same time, checking if the hash table contains the key
+
+            int keySum = 0;
+            int arraySum = 0;
+
+            for (int i = 0; i < 10; i++)
+            {
+                Assert.IsTrue(hashtable.Contains(array[i].Key), "Hashtable should contain the key.");
+                Assert.AreEqual(hashtable[array[i].Key], array[i].Value, "The value associated with the key should be correct.");
+
+                keySum += i * 10;
+                arraySum += (int)hashtable[array[i].Key];
+            }
+
+            Assert.AreEqual(keySum, arraySum, "Sum of value should be the same.");
+        }
 
         #region helper classes and methods
 

--- a/nanoFramework.System.Collections/Collections/Hashtable.cs
+++ b/nanoFramework.System.Collections/Collections/Hashtable.cs
@@ -276,7 +276,7 @@ namespace System.Collections
                 throw new ArgumentNullException();
             }
 
-            if (arrayIndex < 0 && arrayIndex > _buckets.Length)
+            if (arrayIndex < 0 || arrayIndex > _buckets.Length)
             {
 #pragma warning disable S112 // General exceptions should never be thrown
                 throw new ArgumentOutOfRangeException();
@@ -296,12 +296,16 @@ namespace System.Collections
 
                 for (int i = _buckets.Length; --i >= 0;)
                 {
-                    object keyv = _buckets[i]._key;
-
-                    if ((keyv != null) && (keyv != _buckets))
+                    // can only work with buckets that aren't null
+                    if (_buckets[i] != null)
                     {
-                        ((IList)array)[j] = new DictionaryEntry(_buckets[i]._key, _buckets[i]._value);
-                        j++;
+                        object keyv = _buckets[i]._key;
+
+                        if ((keyv != null) && (keyv != _buckets))
+                        {
+                            ((IList)array)[arrayIndex + j] = new DictionaryEntry(keyv, _buckets[i]._value);
+                            j++;
+                        }
                     }
                 }
             }
@@ -658,12 +662,16 @@ namespace System.Collections
 
                 for (int i = _buckets.Length; --i >= 0;)
                 {
-                    object keyv = _buckets[i]._key;
-
-                    if ((keyv != null) && (keyv != _buckets))
+                    // can only work with buckets that aren't null
+                    if (_buckets[i] != null)
                     {
-                        ((IList)array)[arrayIndex + j] = _buckets[i]._value;
-                        j++;
+                        object keyv = _buckets[i]._key;
+
+                        if ((keyv != null) && (keyv != _buckets))
+                        {
+                            ((IList)array)[arrayIndex + j] = _buckets[i]._value;
+                            j++;
+                        }
                     }
                 }
             }


### PR DESCRIPTION
## Description
- Need to check for null element before trying to access the key.
- Add new unit tests to cover the various CopyTo.

## Motivation and Context

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (IF APPROPRIATE): -->

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ ] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [x] Unit Tests (add new Unit Test(s) or improved existing one(s), has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [x] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [x] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
- [x] I have added new tests to cover my changes.
