### PR TITLE
Add new units test for generics collection

### DIFF
--- a/Tests/GenericCollections/ListTests.cs
+++ b/Tests/GenericCollections/ListTests.cs
@@ -1130,59 +1130,56 @@ namespace GenericCollections
             Assert.AreEqual(15, result);
         }
 
-        //[TestMethod]
-        //public void List_GenericMethod_NewObj_Foreach_String()
-        //{
-        //    string result = ConcatList(new string[] { "Hello", " ", "World" });
-        //    Assert.AreEqual("Hello World", result);
-        //}
+        [TestMethod]
+        public void List_GenericMethod_NewObj_Foreach_String()
+        {
+            string result = ConcatList(new string[] { "Hello", " ", "World" });
+            Assert.AreEqual("Hello World", result);
+        }
 
-        //[TestMethod]
-        //public void List_GenericMethod_NewObj_Foreach_Class()
-        //{
-        //    var items = new DummyClass[]
-        //    {
-        //        new(1, "One"),
-        //        new(2, "Two"),
-        //        new(3, "Three")
-        //    };
+        [TestMethod]
+        public void List_GenericMethod_NewObj_Foreach_Class()
+        {
+            var items = new DummyClass[]
+            {
+                new(1, "One"),
+                new(2, "Two"),
+                new(3, "Three")
+            };
 
-        //    var result = CollectFromList(items);
-        //    Assert.AreEqual(3, result.Length);
-        //    Assert.AreEqual(1, result[0].Id);
-        //    Assert.AreEqual("Two", result[1].Name);
-        //    Assert.AreEqual(3, result[2].Id);
-        //}
+            var result = CollectFromList(items);
+            Assert.AreEqual(3, result.Length);
+            Assert.AreEqual(1, result[0].Id);
+            Assert.AreEqual("Two", result[1].Name);
+            Assert.AreEqual(3, result[2].Id);
+        }
 
-        // TODO: fix parsing test result
-        //[TestMethod]
-        //public void List_GenericMethod_NewObj_Contains()
-        //{
-        //    Assert.IsTrue(ListContains(new int[] { 1, 2, 3 }, 2));
-        //    Assert.IsFalse(ListContains(new int[] { 1, 2, 3 }, 5));
+        [TestMethod]
+        public void List_GenericMethod_NewObj_Contains()
+        {
+            Assert.IsTrue(ListContains(new int[] { 1, 2, 3 }, 2));
+            Assert.IsFalse(ListContains(new int[] { 1, 2, 3 }, 5));
 
-        //    Assert.IsTrue(ListContains(new string[] { "A", "B", "C" }, "B"));
-        //    Assert.IsFalse(ListContains(new string[] { "A", "B", "C" }, "Z"));
-        //}
+            Assert.IsTrue(ListContains(new string[] { "A", "B", "C" }, "B"));
+            Assert.IsFalse(ListContains(new string[] { "A", "B", "C" }, "Z"));
+        }
 
-        // TODO: requires fixing support for nested VAR token resolution
-        //[TestMethod]
-        //public void List_GenericMethod_NewObj_AddAndCount()
-        //{
-        //    Assert.AreEqual(5, BuildListAndCount(1, 2, 3, 4, 5));
-        //    Assert.AreEqual(3, BuildListAndCount("A", "B", "C"));
-        //}
+        [TestMethod]
+        public void List_GenericMethod_NewObj_AddAndCount()
+        {
+            Assert.AreEqual(5, BuildListAndCount(1, 2, 3, 4, 5));
+            Assert.AreEqual(3, BuildListAndCount("A", "B", "C"));
+        }
 
-        // TODO: fix parsing test result
-        //[TestMethod]
-        //public void List_GenericMethod_NewObj_IndexOf()
-        //{
-        //    Assert.AreEqual(2, ListIndexOf(new int[] { 10, 20, 30, 40 }, 30));
-        //    Assert.AreEqual(-1, ListIndexOf(new int[] { 10, 20, 30, 40 }, 99));
+        [TestMethod]
+        public void List_GenericMethod_NewObj_IndexOf()
+        {
+            Assert.AreEqual(2, ListIndexOf(new int[] { 10, 20, 30, 40 }, 30));
+            Assert.AreEqual(-1, ListIndexOf(new int[] { 10, 20, 30, 40 }, 99));
 
-        //    Assert.AreEqual(1, ListIndexOf(new string[] { "X", "Y", "Z" }, "Y"));
-        //    Assert.AreEqual(-1, ListIndexOf(new string[] { "X", "Y", "Z" }, "W"));
-        //}
+            Assert.AreEqual(1, ListIndexOf(new string[] { "X", "Y", "Z" }, "Y"));
+            Assert.AreEqual(-1, ListIndexOf(new string[] { "X", "Y", "Z" }, "W"));
+        }
 
         [TestMethod]
         public void List_GenericMethod_NewObj_RemoveAndVerify()


### PR DESCRIPTION
## Description
- Add new units test for generics collections.

## Motivation and Context
- Previously commented out because of issue in nanoCLR.
- Required fixes to run this successfully added with nanoframework/nf-interpreter#3338.
- Related with nanoframework/Home#782.

## How Has This Been Tested?<!-- (IF APPLICABLE) -->

## Screenshots<!-- (IF APPROPRIATE): -->

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ ] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [x] Unit Tests (add new Unit Test(s) or improved existing one(s), has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [x] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [x] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
- [ ] I have added new tests to cover my changes.
